### PR TITLE
Fix CSS build inconsistency between development and production

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -72,8 +72,8 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Build assets (Tailwind CSS and Webpack)
-        run: npm run build:css && npm run build:assets
+      - name: Build assets (Webpack)
+        run: npm run build:assets
 
       - name: Setup Hugo
         uses: peaceiris/actions-hugo@v2

--- a/README.md
+++ b/README.md
@@ -117,10 +117,8 @@ npm --version
 
 - `npm run dev` - Start the Hugo development server with asset watching
 - `npm run build` - Build the Hugo site for production
-- `npm run build:assets` - Build frontend assets with Webpack
-- `npm run watch:assets` - Watch and rebuild frontend assets during development
-- `npm run build:css` - Build and minify Tailwind CSS
-- `npm run watch:css` - Watch and rebuild Tailwind CSS during development
+- `npm run build:assets` - Build all frontend assets (CSS + JavaScript) with Webpack
+- `npm run watch:assets` - Watch and rebuild all frontend assets during development
 - `npm run start` - Build assets and start Hugo server
 - `npm run clean` - Clean generated assets
 
@@ -722,7 +720,7 @@ This project uses [Tailwind CSS](https://tailwindcss.com/docs) for styling. You 
 
 1. Editing the `tailwind.config.js` file to modify colors, fonts, and other design tokens
 2. Adding custom CSS in the `static/css/src/` directory
-3. Rebuilding CSS with `npm run build:css`
+3. Rebuilding assets with `npm run build:assets`
 
 For more information on Tailwind CSS utility classes and configuration options, refer to the [official Tailwind CSS documentation](https://tailwindcss.com/docs).
 

--- a/package.json
+++ b/package.json
@@ -3,12 +3,10 @@
   "version": "1.0.0",
   "description": "Waterways Cleanup Project",
   "scripts": {
-    "dev": "concurrently \"hugo server\" \"npm run watch:assets\" \"npm run watch:css\"",
-    "build": "npm run build:css && npm run build:assets && hugo --minify",
+    "dev": "concurrently \"hugo server\" \"npm run watch:assets\"",
+    "build": "npm run build:assets && hugo --minify",
     "build:assets": "webpack --mode production",
-    "build:css": "tailwindcss -i ./static/css/src/tailwind.css -o ./static/css/tailwind-output.css --minify",
     "watch:assets": "webpack --watch --mode development",
-    "watch:css": "tailwindcss -i ./static/css/src/tailwind.css -o ./static/css/tailwind-output.css --watch",
     "clean": "rm -f static/css/tailwind-output.css static/js/main-bundle.js",
     "start": "npm run build && hugo server"
   },

--- a/static/css/tailwind-output.css
+++ b/static/css/tailwind-output.css
@@ -385,7 +385,9 @@
   html, :host {
     line-height: 1.5;
     -webkit-text-size-adjust: 100%;
-    tab-size: 4;
+    -moz-tab-size: 4;
+      -o-tab-size: 4;
+         tab-size: 4;
     font-family: var(--default-font-family, ui-sans-serif, system-ui, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji");
     font-feature-settings: var(--default-font-feature-settings, normal);
     font-variation-settings: var(--default-font-variation-settings, normal);
@@ -477,10 +479,19 @@
   ::file-selector-button {
     margin-inline-end: 4px;
   }
+  ::-moz-placeholder {
+    opacity: 1;
+  }
   ::placeholder {
     opacity: 1;
   }
   @supports (not (-webkit-appearance: -apple-pay-button))  or (contain-intrinsic-size: 1px) {
+    ::-moz-placeholder {
+      color: currentcolor;
+      @supports (color: color-mix(in lab, red, red)) {
+        color: color-mix(in oklab, currentcolor 50%, transparent);
+      }
+    }
     ::placeholder {
       color: currentcolor;
       @supports (color: color-mix(in lab, red, red)) {
@@ -511,7 +522,9 @@
     box-shadow: none;
   }
   button, input:where([type="button"], [type="reset"], [type="submit"]), ::file-selector-button {
-    appearance: button;
+    -webkit-appearance: button;
+       -moz-appearance: button;
+            appearance: button;
   }
   ::-webkit-inner-spin-button, ::-webkit-outer-spin-button {
     height: auto;
@@ -527,7 +540,9 @@
     width: 100%;
     overflow: hidden;
     webkit-user-select: none;
-    user-select: none;
+    -webkit-user-select: none;
+       -moz-user-select: none;
+            user-select: none;
     direction: ltr;
     container-type: inline-size;
     grid-template-columns: auto 1fr;
@@ -633,6 +648,7 @@
       line-height: 1.25;
       transition: opacity 0.2s cubic-bezier(0.4, 0, 0.2, 1) 75ms, transform 0.2s cubic-bezier(0.4, 0, 0.2, 1) 75ms;
       background-color: var(--tt-bg);
+      width: -moz-max-content;
       width: max-content;
       pointer-events: none;
       z-index: 2;
@@ -650,10 +666,13 @@
       width: 0.625rem;
       height: 0.25rem;
       display: block;
-      mask-repeat: no-repeat;
-      mask-position: -1px 0;
-      --mask-tooltip: url("data:image/svg+xml,%3Csvg width='10' height='4' viewBox='0 0 8 4' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M0.500009 1C3.5 1 3.00001 4 5.00001 4C7 4 6.5 1 9.5 1C10 1 10 0.499897 10 0H0C-1.99338e-08 0.5 0 1 0.500009 1Z' fill='black'/%3E%3C/svg%3E%0A");
-      mask-image: var(--mask-tooltip);
+      -webkit-mask-repeat: no-repeat;
+              mask-repeat: no-repeat;
+      -webkit-mask-position: -1px 0;
+              mask-position: -1px 0;
+      --mask-tooltip: url("data:image/svg+xml,%3Csvg width=%2710%27 height=%274%27 viewBox=%270 0 8 4%27 fill=%27none%27 xmlns=%27http://www.w3.org/2000/svg%27%3E%3Cpath d=%27M0.500009 1C3.5 1 3.00001 4 5.00001 4C7 4 6.5 1 9.5 1C10 1 10 0.499897 10 0H0C-1.99338e-08 0.5 0 1 0.500009 1Z%27 fill=%27black%27/%3E%3C/svg%3E%0A");
+      -webkit-mask-image: var(--mask-tooltip);
+              mask-image: var(--mask-tooltip);
     }
     &.tooltip-open, &[data-tip]:not([data-tip=""]):hover, &:not(:has(.tooltip-content:empty)):has(.tooltip-content):hover, &:has(:focus-visible) {
       > .tooltip-content, &[data-tip]:before, &:after {
@@ -675,13 +694,17 @@
     position: relative;
     display: inline-flex;
     cursor: pointer;
-    appearance: none;
+    -webkit-appearance: none;
+       -moz-appearance: none;
+            appearance: none;
     flex-wrap: wrap;
     align-items: center;
     justify-content: center;
     text-align: center;
     webkit-user-select: none;
-    user-select: none;
+    -webkit-user-select: none;
+       -moz-user-select: none;
+            user-select: none;
     &:hover {
       @media (hover: hover) {
         color: var(--color-base-content);
@@ -703,6 +726,7 @@
     padding-inline-start: var(--tab-p);
     padding-inline-end: var(--tab-p);
     &:is(input[type="radio"]) {
+      min-width: -moz-fit-content;
       min-width: fit-content;
       &:after {
         content: attr(aria-label);
@@ -714,7 +738,9 @@
         position: absolute;
         inset: calc(0.25rem * 0);
         cursor: pointer;
-        appearance: none;
+        -webkit-appearance: none;
+           -moz-appearance: none;
+                appearance: none;
         opacity: 0%;
       }
     }
@@ -753,6 +779,7 @@
   }
   .menu {
     display: flex;
+    width: -moz-fit-content;
     width: fit-content;
     flex-direction: column;
     flex-wrap: wrap;
@@ -794,7 +821,9 @@
       transition-timing-function: cubic-bezier(0, 0, 0.2, 1);
       grid-auto-columns: minmax(auto, max-content) auto max-content;
       text-wrap: balance;
-      user-select: none;
+      -webkit-user-select: none;
+         -moz-user-select: none;
+              user-select: none;
     }
     :where(li > details > summary) {
       --tw-outline-style: none;
@@ -1006,10 +1035,14 @@
     background-color: currentColor;
     vertical-align: middle;
     width: calc(var(--size-selector, 0.25rem) * 6);
-    mask-size: 100%;
-    mask-repeat: no-repeat;
-    mask-position: center;
-    mask-image: url("data:image/svg+xml,%3Csvg width='24' height='24' stroke='black' viewBox='0 0 24 24' xmlns='http://www.w3.org/2000/svg'%3E%3Cg transform-origin='center'%3E%3Ccircle cx='12' cy='12' r='9.5' fill='none' stroke-width='3' stroke-linecap='round'%3E%3CanimateTransform attributeName='transform' type='rotate' from='0 12 12' to='360 12 12' dur='2s' repeatCount='indefinite'/%3E%3Canimate attributeName='stroke-dasharray' values='0,150;42,150;42,150' keyTimes='0;0.475;1' dur='1.5s' repeatCount='indefinite'/%3E%3Canimate attributeName='stroke-dashoffset' values='0;-16;-59' keyTimes='0;0.475;1' dur='1.5s' repeatCount='indefinite'/%3E%3C/circle%3E%3C/g%3E%3C/svg%3E");
+    -webkit-mask-size: 100%;
+            mask-size: 100%;
+    -webkit-mask-repeat: no-repeat;
+            mask-repeat: no-repeat;
+    -webkit-mask-position: center;
+            mask-position: center;
+    -webkit-mask-image: url("data:image/svg+xml,%3Csvg width=%2724%27 height=%2724%27 stroke=%27black%27 viewBox=%270 0 24 24%27 xmlns=%27http://www.w3.org/2000/svg%27%3E%3Cg transform-origin=%27center%27%3E%3Ccircle cx=%2712%27 cy=%2712%27 r=%279.5%27 fill=%27none%27 stroke-width=%273%27 stroke-linecap=%27round%27%3E%3CanimateTransform attributeName=%27transform%27 type=%27rotate%27 from=%270 12 12%27 to=%27360 12 12%27 dur=%272s%27 repeatCount=%27indefinite%27/%3E%3Canimate attributeName=%27stroke-dasharray%27 values=%270,150;42,150;42,150%27 keyTimes=%270;0.475;1%27 dur=%271.5s%27 repeatCount=%27indefinite%27/%3E%3Canimate attributeName=%27stroke-dashoffset%27 values=%270;-16;-59%27 keyTimes=%270;0.475;1%27 dur=%271.5s%27 repeatCount=%27indefinite%27/%3E%3C/circle%3E%3C/g%3E%3C/svg%3E");
+            mask-image: url("data:image/svg+xml,%3Csvg width=%2724%27 height=%2724%27 stroke=%27black%27 viewBox=%270 0 24 24%27 xmlns=%27http://www.w3.org/2000/svg%27%3E%3Cg transform-origin=%27center%27%3E%3Ccircle cx=%2712%27 cy=%2712%27 r=%279.5%27 fill=%27none%27 stroke-width=%273%27 stroke-linecap=%27round%27%3E%3CanimateTransform attributeName=%27transform%27 type=%27rotate%27 from=%270 12 12%27 to=%27360 12 12%27 dur=%272s%27 repeatCount=%27indefinite%27/%3E%3Canimate attributeName=%27stroke-dasharray%27 values=%270,150;42,150;42,150%27 keyTimes=%270;0.475;1%27 dur=%271.5s%27 repeatCount=%27indefinite%27/%3E%3Canimate attributeName=%27stroke-dashoffset%27 values=%270;-16;-59%27 keyTimes=%270;0.475;1%27 dur=%271.5s%27 repeatCount=%27indefinite%27/%3E%3C/circle%3E%3C/g%3E%3C/svg%3E");
   }
   .invisible {
     visibility: hidden;
@@ -1130,11 +1163,15 @@
     display: inline-grid;
     flex-shrink: 0;
     cursor: pointer;
-    appearance: none;
+    -webkit-appearance: none;
+       -moz-appearance: none;
+            appearance: none;
     place-content: center;
     vertical-align: middle;
     webkit-user-select: none;
-    user-select: none;
+    -webkit-user-select: none;
+       -moz-user-select: none;
+            user-select: none;
     grid-template-columns: 0fr 1fr 1fr;
     --radius-selector-max: calc(
     var(--radius-selector) + var(--radius-selector) + var(--radius-selector)
@@ -1161,7 +1198,9 @@
       grid-row-start: 1;
       height: 100%;
       cursor: pointer;
-      appearance: none;
+      -webkit-appearance: none;
+         -moz-appearance: none;
+              appearance: none;
       background-color: transparent;
       padding: calc(0.25rem * 0.5);
       transition: opacity 0.2s, rotate 0.4s;
@@ -1262,7 +1301,9 @@
     position: relative;
     display: inline-flex;
     flex-shrink: 1;
-    appearance: none;
+    -webkit-appearance: none;
+       -moz-appearance: none;
+            appearance: none;
     align-items: center;
     gap: calc(0.25rem * 2);
     background-color: var(--color-base-100);
@@ -1294,7 +1335,9 @@
       display: inline-flex;
       height: 100%;
       width: 100%;
-      appearance: none;
+      -webkit-appearance: none;
+         -moz-appearance: none;
+              appearance: none;
       background-color: transparent;
       border: none;
       &:focus, &:focus-within {
@@ -1331,6 +1374,12 @@
       @supports (color: color-mix(in lab, red, red)) {
         color: color-mix(in oklab, var(--color-base-content) 40%, transparent);
       }
+      &::-moz-placeholder {
+        color: var(--color-base-content);
+        @supports (color: color-mix(in lab, red, red)) {
+          color: color-mix(in oklab, var(--color-base-content) 20%, transparent);
+        }
+      }
       &::placeholder {
         color: var(--color-base-content);
         @supports (color: color-mix(in lab, red, red)) {
@@ -1359,6 +1408,7 @@
   .indicator {
     position: relative;
     display: inline-flex;
+    width: -moz-max-content;
     width: max-content;
     :where(.indicator-item) {
       z-index: 1;
@@ -1539,7 +1589,9 @@
     }
   }
   .range {
-    appearance: none;
+    -webkit-appearance: none;
+       -moz-appearance: none;
+            appearance: none;
     webkit-appearance: none;
     --range-thumb: var(--color-base-100);
     --range-thumb-size: calc(var(--size-selector, 0.25rem) * 6);
@@ -1595,7 +1647,8 @@
       height: var(--range-thumb-size);
       width: var(--range-thumb-size);
       border: var(--range-p) solid;
-      appearance: none;
+      -webkit-appearance: none;
+              appearance: none;
       webkit-appearance: none;
       top: 50%;
       color: var(--range-progress);
@@ -1636,7 +1689,9 @@
     position: relative;
     display: inline-flex;
     flex-shrink: 1;
-    appearance: none;
+    -webkit-appearance: none;
+       -moz-appearance: none;
+            appearance: none;
     align-items: center;
     gap: calc(0.25rem * 1.5);
     background-color: var(--color-base-100);
@@ -1673,7 +1728,9 @@
       margin-inline-start: calc(0.25rem * -4);
       margin-inline-end: calc(0.25rem * -7);
       width: calc(100% + 2.75rem);
-      appearance: none;
+      -webkit-appearance: none;
+         -moz-appearance: none;
+              appearance: none;
       padding-inline-start: calc(0.25rem * 4);
       padding-inline-end: calc(0.25rem * 7);
       height: calc(100% - 2px);
@@ -1711,6 +1768,12 @@
       color: var(--color-base-content);
       @supports (color: color-mix(in lab, red, red)) {
         color: color-mix(in oklab, var(--color-base-content) 40%, transparent);
+      }
+      &::-moz-placeholder {
+        color: var(--color-base-content);
+        @supports (color: color-mix(in lab, red, red)) {
+          color: color-mix(in oklab, var(--color-base-content) 20%, transparent);
+        }
       }
       &::placeholder {
         color: var(--color-base-content);
@@ -1791,9 +1854,13 @@
     place-content: center;
     vertical-align: middle;
     webkit-user-select: none;
-    user-select: none;
+    -webkit-user-select: none;
+       -moz-user-select: none;
+            user-select: none;
     input {
-      appearance: none;
+      -webkit-appearance: none;
+         -moz-appearance: none;
+              appearance: none;
       border: none;
     }
     > * {
@@ -1839,7 +1906,8 @@
     img {
       height: 100%;
       width: 100%;
-      object-fit: cover;
+      -o-object-fit: cover;
+         object-fit: cover;
     }
   }
   .checkbox {
@@ -1851,7 +1919,9 @@
     display: inline-block;
     flex-shrink: 0;
     cursor: pointer;
-    appearance: none;
+    -webkit-appearance: none;
+       -moz-appearance: none;
+            appearance: none;
     border-radius: var(--radius-selector);
     padding: calc(0.25rem * 1);
     vertical-align: middle;
@@ -1925,7 +1995,9 @@
     display: inline-block;
     flex-shrink: 0;
     cursor: pointer;
-    appearance: none;
+    -webkit-appearance: none;
+       -moz-appearance: none;
+            appearance: none;
     border-radius: calc(infinity * 1px);
     padding: calc(0.25rem * 1);
     vertical-align: middle;
@@ -1982,7 +2054,9 @@
     position: relative;
     height: calc(0.25rem * 2);
     width: 100%;
-    appearance: none;
+    -webkit-appearance: none;
+       -moz-appearance: none;
+            appearance: none;
     overflow: hidden;
     border-radius: var(--radius-box);
     background-color: currentColor;
@@ -2059,7 +2133,9 @@
     border: var(--border) solid #0000;
     min-height: calc(0.25rem * 20);
     flex-shrink: 1;
-    appearance: none;
+    -webkit-appearance: none;
+       -moz-appearance: none;
+            appearance: none;
     border-radius: var(--radius-field);
     background-color: var(--color-base-100);
     padding-block: calc(0.25rem * 2);
@@ -2079,7 +2155,9 @@
       --input-color: color-mix(in oklab, var(--color-base-content) 20%, #0000);
     }
     textarea {
-      appearance: none;
+      -webkit-appearance: none;
+         -moz-appearance: none;
+              appearance: none;
       background-color: transparent;
       border: none;
       &:focus, &:focus-within {
@@ -2108,6 +2186,12 @@
       color: var(--color-base-content);
       @supports (color: color-mix(in lab, red, red)) {
         color: color-mix(in oklab, var(--color-base-content) 40%, transparent);
+      }
+      &::-moz-placeholder {
+        color: var(--color-base-content);
+        @supports (color: color-mix(in lab, red, red)) {
+          color: color-mix(in oklab, var(--color-base-content) 20%, transparent);
+        }
       }
       &::placeholder {
         color: var(--color-base-content);
@@ -2360,6 +2444,7 @@
     padding-block: calc(0.25rem * 2);
     > menu, > ul, > ol {
       display: flex;
+      min-height: -moz-min-content;
       min-height: min-content;
       align-items: center;
       white-space: nowrap;
@@ -2489,6 +2574,7 @@
     color: var(--badge-fg) !important;
     border: var(--border) solid var(--badge-color, var(--color-base-200)) !important;
     font-size: 0.875rem !important;
+    width: -moz-fit-content !important;
     width: fit-content !important;
     padding-inline: calc(0.25rem * 3 - var(--border)) !important;
     background-size: auto, calc(var(--noise) * 100%) !important;
@@ -2509,6 +2595,7 @@
     color: var(--badge-fg);
     border: var(--border) solid var(--badge-color, var(--color-base-200));
     font-size: 0.875rem;
+    width: -moz-fit-content;
     width: fit-content;
     padding-inline: calc(0.25rem * 3 - var(--border));
     background-size: auto, calc(var(--noise) * 100%);
@@ -2555,7 +2642,8 @@
     width: 100%;
     grid-auto-flow: row;
     place-items: start;
-    column-gap: calc(0.25rem * 4);
+    -moz-column-gap: calc(0.25rem * 4);
+         column-gap: calc(0.25rem * 4);
     row-gap: calc(0.25rem * 10);
     font-size: 0.875rem;
     line-height: 1.25rem;
@@ -2754,9 +2842,12 @@
   .mask {
     display: inline-block;
     vertical-align: middle;
-    mask-size: contain;
-    mask-repeat: no-repeat;
-    mask-position: center;
+    -webkit-mask-size: contain;
+            mask-size: contain;
+    -webkit-mask-repeat: no-repeat;
+            mask-repeat: no-repeat;
+    -webkit-mask-position: center;
+            mask-position: center;
   }
   .block {
     display: block;
@@ -2939,7 +3030,9 @@
     list-style-type: disc;
   }
   .appearance-none {
-    appearance: none;
+    -webkit-appearance: none;
+       -moz-appearance: none;
+            appearance: none;
   }
   .grid-cols-1 {
     grid-template-columns: repeat(1, minmax(0, 1fr));
@@ -3961,7 +4054,7 @@
 }
 @layer base {
   :root {
-    --fx-noise: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='a'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='1.34' numOctaves='4' stitchTiles='stitch'%3E%3C/feTurbulence%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23a)' opacity='0.2'%3E%3C/rect%3E%3C/svg%3E");
+    --fx-noise: url("data:image/svg+xml,%3Csvg xmlns=%27http://www.w3.org/2000/svg%27%3E%3Cfilter id=%27a%27%3E%3CfeTurbulence type=%27fractalNoise%27 baseFrequency=%271.34%27 numOctaves=%274%27 stitchTiles=%27stitch%27%3E%3C/feTurbulence%3E%3C/filter%3E%3Crect width=%27100%25%27 height=%27100%25%27 filter=%27url%28%23a%29%27 opacity=%270.2%27%3E%3C/rect%3E%3C/svg%3E");
   }
 }
 @layer base {
@@ -4294,4 +4387,4 @@
       --tw-drop-shadow-size: initial;
     }
   }
-}
+} 


### PR DESCRIPTION
## Summary
- Fixes inconsistent CSS generation between development and production builds
- Removes dual CSS build paths that caused different utility class inclusion
- Simplifies build pipeline to use single webpack-based process
- Closes #32

## Problem
The project had two different CSS build methods:
1. `npm run build:css` using Tailwind CLI
2. `npm run build:assets` using webpack with PostCSS

These generated different CSS due to:
- Different content scanning behavior (clean vs dirty working directories)
- Different processing pipelines and vendor prefix handling
- Race conditions in webpack's file copy logic

This caused developers to see different CSS locally than what was deployed to production.

## Solution
- Remove `build:css` and `watch:css` npm scripts
- Update GitHub Actions to use only `build:assets`
- Ensure consistent webpack-based build process for all environments
- Update documentation to reflect simplified workflow

## Test Plan
- [x] Verified clean repository generates same CSS as production
- [x] Confirmed webpack build includes proper vendor prefixes
- [x] Updated all documentation references
- [x] Tested build process in clean environment

If CSS-only builds are needed in the future, they should be implemented using webpack configuration rather than separate Tailwind CLI commands.